### PR TITLE
Add reddit_share_link tag for sharing on Reddit

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,35 @@ Follow tags:
 {% gplus_profile_link %}
 ```
 
+## Reddit
+
+Configure this plugin in your site's `_config.yml`. No configurations are required. Here are the configuration defaults.
+
+```yaml
+reddit:
+  share_link_text:   Reddit           # Configure the link text
+  share_link_title:  Share on Reddit  # Title of the share link
+  share_title:       :title - :url    # The suggested title auto-filled in the reddit form
+```
+
+To include a custom auto-filled share title for a post or page, include a
+`reddit_share_title` attribute in the frontmatter of the post/page like this:
+
+```yaml
+reddit_share_title: "Totally not click bait! :title - :url"
+```
+
+### Reddit Tags
+
+Sharing tags:
+```
+{% reddit_share_link %}      # Share with a (no js) link
+```
+
+The share button will open a new page with a pre-filled Reddit submission form
+with a title derived from the `share_title` or page/post specific
+`reddit_share_title` configuration discussed above.
+
 ## Email sharing
 
 Add convenient `mail:to` links which which helps readers

--- a/lib/octopress-social.rb
+++ b/lib/octopress-social.rb
@@ -13,7 +13,8 @@ module Octopress
     autoload :Disqus,         'octopress-social/disqus'
     autoload :Email,          'octopress-social/email'
     autoload :GitHub,         'octopress-social/github'
-    
+    autoload :Reddit,         'octopress-social/reddit'
+
     def full_url(site, item)
       unless root = site['url']
         abort "Site url not configured. Please set url: http://your-site.com in Jekyll configuration file."
@@ -62,6 +63,7 @@ Liquid::Template.register_tag('disqus_comments_link', Octopress::Social::Disqus:
 Liquid::Template.register_tag('email_share_link', Octopress::Social::Email::Tag)
 Liquid::Template.register_tag('email_contact_link', Octopress::Social::Email::Tag)
 Liquid::Template.register_tag('github_profile_link', Octopress::Social::GitHub::Tag)
+Liquid::Template.register_tag('reddit_share_link', Octopress::Social::Reddit::Tag)
 
 if defined? Octopress::Docs
   Octopress::Docs.add({

--- a/lib/octopress-social/reddit.rb
+++ b/lib/octopress-social/reddit.rb
@@ -1,0 +1,65 @@
+# encoding: UTF-8
+module Octopress
+  module Social
+    module Reddit
+      extend self
+
+      attr_accessor :url, :config
+
+      DEFAULTS = {
+        'share_link_text'     => 'Reddit',
+        'share_link_title'    => 'Share on Reddit',
+        'share_title'         => ':title - :url',
+      }
+
+      def set_config(site)
+        @config ||= begin
+          config = site['octopress_social'] || site
+          DEFAULTS.merge(config['reddit'] || {})
+        end
+      end
+
+      def set_url(site, item)
+        @url = Social.full_url(site, item)
+      end
+
+      def reddit_share_link(site, item)
+        %Q{<a
+          class="reddit-share-link"
+          href="#{reddit_share_url(site, item)}"
+          title="#{config['share_link_title']}">#{config['share_link_text']}</a>}
+      end
+
+      def reddit_share_url(site, item)
+        encoded_url = ERB::Util.url_encode(url)
+        encoded_share_title = ERB::Util.url_encode(share_title(site, item))
+        "http://www.reddit.com/submit".
+          concat("?title=#{encoded_share_title}").
+          concat("&url=#{encoded_url}")
+      end
+
+      def share_title(site, item)
+        (item['reddit_share_title'] || config['share_title'])
+          .gsub(':title', item['title'] || '')
+          .gsub(':url', url)
+          .strip
+      end
+
+      class Tag < Liquid::Tag
+        def initialize(tag, input, tokens)
+          @tag = tag.strip
+          @input = input.strip
+        end
+
+        def render(context)
+          site = context['site']
+          item = Octopress::Social.item(context, @input)
+
+          Octopress::Social::Reddit.set_config(site)
+          Octopress::Social::Reddit.set_url(site, item)
+          Octopress::Social::Reddit.send(@tag, site, item).gsub(/(\s{2,}|\n)/, ' ').strip
+        end
+      end
+    end
+  end
+end

--- a/test/site/_expected/post-loop.html
+++ b/test/site/_expected/post-loop.html
@@ -14,6 +14,7 @@ Share Links:
 <a class="g-plus-share-link" href="https://plus.google.com/share?url=http://example.com/blog/share-post/" title="Share on Google+">Google+</a>
 <a class="facebook-share-link" href="https://www.facebook.com/sharer/sharer.php?u=http://example.com/blog/share-post/" title="Share on Facebook">Facebook</a>
 <a class="email-share-link" href="mailto:?subject=Share%20post%20by%20Guy%20McDude&body=Share%20post%20by%20Guy%20McDude%20-%20http%3A%2F%2Fexample.com%2Fblog%2Fshare-post%2F" title="Share via email">Email</a>
+<a class="reddit-share-link" href="http://www.reddit.com/submit?title=Share%20post%20-%20http%3A%2F%2Fexample.com%2Fblog%2Fshare-post%2F&url=http%3A%2F%2Fexample.com%2Fblog%2Fshare-post%2F" title="Share on Reddit">Reddit</a>
 
 Comment links:
 <a class="disqus-comments-link" title="View comments" href="http://example.com/blog/share-post/#disqus_thread">Comments</a>

--- a/test/site/_expected/share-page.html
+++ b/test/site/_expected/share-page.html
@@ -12,6 +12,7 @@ Share Links:
 <a class="g-plus-share-link" href="https://plus.google.com/share?url=http://example.com/blog/share-page.html" title="Share on Google+">Google+</a>
 <a class="facebook-share-link" href="https://www.facebook.com/sharer/sharer.php?u=http://example.com/blog/share-page.html" title="Share on Facebook">Facebook</a>
 <a class="email-share-link" href="mailto:?subject=Cool%20Page%20by%20Guy%20McDude&body=Cool%20Page%20by%20Guy%20McDude%20-%20http%3A%2F%2Fexample.com%2Fblog%2Fshare-page.html" title="Share via email">Email</a>
+<a class="reddit-share-link" href="http://www.reddit.com/submit?title=Cool%20Page%20-%20http%3A%2F%2Fexample.com%2Fblog%2Fshare-page.html&url=http%3A%2F%2Fexample.com%2Fblog%2Fshare-page.html" title="Share on Reddit">Reddit</a>
 
 Comment links:
 <a class="disqus-comments-link" title="View comments" href="#disqus_thread">Comments</a>

--- a/test/site/_expected/share-post/index.html
+++ b/test/site/_expected/share-post/index.html
@@ -12,6 +12,7 @@ Share Links:
 <a class="g-plus-share-link" href="https://plus.google.com/share?url=http://example.com/blog/share-post/" title="Share on Google+">Google+</a>
 <a class="facebook-share-link" href="https://www.facebook.com/sharer/sharer.php?u=http://example.com/blog/share-post/" title="Share on Facebook">Facebook</a>
 <a class="email-share-link" href="mailto:?subject=Share%20post%20by%20Guy%20McDude&body=Share%20post%20by%20Guy%20McDude%20-%20http%3A%2F%2Fexample.com%2Fblog%2Fshare-post%2F" title="Share via email">Email</a>
+<a class="reddit-share-link" href="http://www.reddit.com/submit?title=Share%20post%20-%20http%3A%2F%2Fexample.com%2Fblog%2Fshare-post%2F&url=http%3A%2F%2Fexample.com%2Fblog%2Fshare-post%2F" title="Share on Reddit">Reddit</a>
 
 Comment links:
 <a class="disqus-comments-link" title="View comments" href="#disqus_thread">Comments</a>

--- a/test/site/_includes/share.html
+++ b/test/site/_includes/share.html
@@ -10,3 +10,4 @@ Share Links:
 {% gplus_share_link %}
 {% facebook_share_link %}
 {% email_share_link %}
+{% reddit_share_link %}

--- a/test/site/_site/post-loop.html
+++ b/test/site/_site/post-loop.html
@@ -14,6 +14,7 @@ Share Links:
 <a class="g-plus-share-link" href="https://plus.google.com/share?url=http://example.com/blog/share-post/" title="Share on Google+">Google+</a>
 <a class="facebook-share-link" href="https://www.facebook.com/sharer/sharer.php?u=http://example.com/blog/share-post/" title="Share on Facebook">Facebook</a>
 <a class="email-share-link" href="mailto:?subject=Share%20post%20by%20Guy%20McDude&body=Share%20post%20by%20Guy%20McDude%20-%20http%3A%2F%2Fexample.com%2Fblog%2Fshare-post%2F" title="Share via email">Email</a>
+<a class="reddit-share-link" href="http://www.reddit.com/submit?title=Share%20post%20-%20http%3A%2F%2Fexample.com%2Fblog%2Fshare-post%2F&url=http%3A%2F%2Fexample.com%2Fblog%2Fshare-post%2F" title="Share on Reddit">Reddit</a>
 
 Comment links:
 <a class="disqus-comments-link" title="View comments" href="http://example.com/blog/share-post/#disqus_thread">Comments</a>

--- a/test/site/_site/share-page.html
+++ b/test/site/_site/share-page.html
@@ -12,6 +12,7 @@ Share Links:
 <a class="g-plus-share-link" href="https://plus.google.com/share?url=http://example.com/blog/share-page.html" title="Share on Google+">Google+</a>
 <a class="facebook-share-link" href="https://www.facebook.com/sharer/sharer.php?u=http://example.com/blog/share-page.html" title="Share on Facebook">Facebook</a>
 <a class="email-share-link" href="mailto:?subject=Cool%20Page%20by%20Guy%20McDude&body=Cool%20Page%20by%20Guy%20McDude%20-%20http%3A%2F%2Fexample.com%2Fblog%2Fshare-page.html" title="Share via email">Email</a>
+<a class="reddit-share-link" href="http://www.reddit.com/submit?title=Cool%20Page%20-%20http%3A%2F%2Fexample.com%2Fblog%2Fshare-page.html&url=http%3A%2F%2Fexample.com%2Fblog%2Fshare-page.html" title="Share on Reddit">Reddit</a>
 
 Comment links:
 <a class="disqus-comments-link" title="View comments" href="#disqus_thread">Comments</a>

--- a/test/site/_site/share-post/index.html
+++ b/test/site/_site/share-post/index.html
@@ -12,6 +12,7 @@ Share Links:
 <a class="g-plus-share-link" href="https://plus.google.com/share?url=http://example.com/blog/share-post/" title="Share on Google+">Google+</a>
 <a class="facebook-share-link" href="https://www.facebook.com/sharer/sharer.php?u=http://example.com/blog/share-post/" title="Share on Facebook">Facebook</a>
 <a class="email-share-link" href="mailto:?subject=Share%20post%20by%20Guy%20McDude&body=Share%20post%20by%20Guy%20McDude%20-%20http%3A%2F%2Fexample.com%2Fblog%2Fshare-post%2F" title="Share via email">Email</a>
+<a class="reddit-share-link" href="http://www.reddit.com/submit?title=Share%20post%20-%20http%3A%2F%2Fexample.com%2Fblog%2Fshare-post%2F&url=http%3A%2F%2Fexample.com%2Fblog%2Fshare-post%2F" title="Share on Reddit">Reddit</a>
 
 Comment links:
 <a class="disqus-comments-link" title="View comments" href="#disqus_thread">Comments</a>


### PR DESCRIPTION
Adds a liquid tag, `reddit_share_link`, for sharing via Reddit. Addresses https://github.com/octopress/social/issues/6.

I also proposed #10 in the event that https://github.com/octopress/social/pull/8 is merged first and a `reddit_share_url` helper tag is desired as well.

I kind of flew through this PR, so a sanity check is much appreciated. If this looks good I should be able to assemble an equivalent PR for HackerNews (https://github.com/octopress/social/issues/5) later this week.

Let me know if there are any questions or concerns I can address!

Thanks!
