### PR TITLE
Allow customization of embedded tweets

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Sharing tags:
 {% tweet_link %}          # Tweet with a (no js) link
 ```
 
-The tweet button and tweet link will open a new page with a composed tweet in the format in your Twitter configuration, `:title by :username - :url :hashtags`. 
+The tweet button and tweet link will open a new page with a composed tweet in the format in your Twitter configuration, `:title by :username - :url :hashtags`.
 
 Follow tags:
 
@@ -119,6 +119,18 @@ This will generate a blockquote, much like this one:
 ```
 
 If you include the twitter widget.js in your site, this will automatically be replaced with one of Twitter's fancy embedded tweets.
+
+You can also provide options to customize the appearance of the tweet.  The full list of available options can be seen in [Twitter's Developer Documentation](https://dev.twitter.com/web/embedded-tweets/parameters).
+
+For example:
+
+```
+{% tweet status_url cards: hidden conversation: none theme: dark %}
+  Tweet Text
+{% endtweet %}
+```
+
+This will generate a blockquote as above, but the fancy embedded tweet will not show any embedded media (`cards: hidden`), will not include any of the conversation that the tweet is part of (`conversation: none`), and will display with light text on a dark background (`theme: dark`).
 
 ## Facebook
 


### PR DESCRIPTION
Twitter provides several options for customizing embedded tweets.  The full list is available in [their developer documentation](https://dev.twitter.com/web/embedded-tweets/parameters).  Of particular interest are the ability to turn off embedded media and the ability to show only the tweet and not the surrounding conversation.

This PR adds the ability to provide optional keyword arguments after the tweet status URL.

The parsing code is modeled after some of the bulit-in tags in Liquid itself.  I made one change from that pattern, though, because the attribute parsing code was also catching the URL, resulting in a `data-https` attribute being added.

I did not implement any kind of whitelist or blacklist for keys, though that might be desirable.  I can add it in if you think it necessary.
